### PR TITLE
Update from downstream

### DIFF
--- a/spec/proto/kong/model/negotiation.proto
+++ b/spec/proto/kong/model/negotiation.proto
@@ -7,11 +7,9 @@ option go_package = "github.com/kong/koko/internal/gen/wrpc/kong/model;model";
 message NegotiateServicesRequest {
   DPNodeDescription node = 1;
   repeated ServiceRequest services_requested = 2;
-  map<string, string> metadata = 3;
 }
 
 message DPNodeDescription {
-  string id = 1;
   string type = 2;
   string version = 3;
   string hostname = 4;

--- a/spec/proto/kong/services/config/v1/config.proto
+++ b/spec/proto/kong/services/config/v1/config.proto
@@ -36,15 +36,10 @@ service ConfigService {
   // +wrpc:rpc-id=2
   rpc SyncConfig(SyncConfigRequest) returns (SyncConfigResponse);
 
-  // PingCP notifies that a DP would like CP to send the latest configuration.
-  // Once this call succeeds, CP MUST issue a SyncConfig request to the DP.
-  // DP expects the CP to send an updated configuration (or a no-op) on a
-  // soft real-time basis.
-  // DP can make multiple calls to CP and CP may choose to coallesce multiplee
-  // requests for configuration into a single SyncConfig().
-  //
-  // Configuration is always PUSHed to the DP and so configuration is not sent
-  // as part of the response to this call to simplify implementation.
+  // PingCP reports the current state of a DP, helping the CP to keep an
+  // updated record of the health of DP and if they have received the
+  // latest configuration.
+  // CP may use this information to choose to send a new SyncConfig.
   //
   // Call direction:
   // - DP to CP

--- a/spec/proto/kong/services/negotiation/v1/negotiation.proto
+++ b/spec/proto/kong/services/negotiation/v1/negotiation.proto
@@ -6,9 +6,7 @@ import "kong/model/negotiation.proto";
 
 option go_package = "github.com/kong/koko/internal/gen/wrpc/kong/service/negotiation/v1;v1";
 
-// NegotiationService allows DP and CP to agree on services that can be used on
-// a wRPC connection
-//
+// NegotiationService allows DP to ask for services and CP answer with the accepted version of each
 // +wrpc:service-id=5
 service NegotiationService {
   // NegotiateServices must be the first RPC call initiated by the DP upon a

--- a/spec/proto/kong/services/negotiation/version-negotiation.md
+++ b/spec/proto/kong/services/negotiation/version-negotiation.md
@@ -19,8 +19,6 @@ The `NegotiationService` service is implemented as single wRPC call
   1. Request data:
       - `node`: a structure containing DP node level metadata with the
         following fields:
-        - `id`: a string value containing the node ID of the DP. This value must
-          be unique across all nodes of a cluster on a best-effort basis.
         - `type`: an identifier that recognizes the type of the DP node.  This
           MUST be set to "KONG" for Kong Gateway nodes. CP MUST verify if this
           is set.
@@ -28,6 +26,9 @@ The `NegotiationService` service is implemented as single wRPC call
           is same as Kong version for the Kong Gateway DP.
         - `hostname`: hostname of the underlying node of the DP.  This field is
           optional and is meant to be used for debugging purposes.
+
+        Note that the `version` and `hostname` fields repeat information which
+        MUST be present as query parameters in the WebSocket UPGRADE command.
       - `services_requested`: a repeated list of services being
         requested by the DP. Each object within the array with the
         following keys:

--- a/spec/proto/kong/services/negotiation/version-negotiation.md
+++ b/spec/proto/kong/services/negotiation/version-negotiation.md
@@ -127,9 +127,9 @@ call upon connection.
 
 ### HTTP Protocol
 
-Version negotiating could use an HTTP requests and not a wRPC request.
+Version negotiating could use an HTTP request and not a wRPC request.
 This gives flexibility to change the RPC protocol in future iterations.
-It is expected that the all layers below and including HTTP will not change,
+It is expected that all the layers below and including HTTP will not change,
 but layers above HTTP (like wRPC) may change in future.
 
 It was decided against to use HTTP to satisfy the possibility that
@@ -138,7 +138,7 @@ HTTP requests may be load-balanced across CP nodes.
 ### ALPN in TLS for protocol negotiation
 
 This was avoided to guard against cases where an L7 proxy is being used between
-the DP and CP. The proxy could drop the ALPN as part of connections setup.
+the DP and CP. The proxy could drop the ALPN as part of connection setup.
 
 ## Questions raised and answered
 
@@ -147,7 +147,7 @@ when mTLS is being used for authentication purposes?
 
 Answer:
 - Yes, TLS is required for integrity and confidentiality.
-- Sine authentication happens before negotiation, mTLS or any other auth scheme
+- Since authentication happens before negotiation, mTLS or any other auth scheme
   will be compatible. Details are noted in the authentication flow documnet.
 
 Why can't we use `host_id` field instead of a `hostname` to identify nodes?


### PR DESCRIPTION
There have been a few changes done in both Kong and Koko that weren't upstreamed, so this is an update.
    
 - Remove a couple unused metadata fields in the service negotiation service.
 - In config service, the PingCP method is used only for informational purposes, it doesn't require an immediate config push.
 - Fix several typos in comments.
 - explicitly mention some repeated information between the UPGRADE command and the Negotiation Service request data